### PR TITLE
FIX: 修复组合按键处理优先级问题

### DIFF
--- a/simulator/adapter_layer/button_adapter.c
+++ b/simulator/adapter_layer/button_adapter.c
@@ -3,9 +3,6 @@
 #include "stdio.h"
 #include "../../bits_button.h"
 #define MAX_BUTTONS 10
-// button_adapter.c
-struct button_obj_t button1;
-struct button_obj_t button2;
 
 // 全局按键状态存储
 static uint8_t key_states[MAX_BUTTONS] = {0};
@@ -49,9 +46,9 @@ int my_log_printf(const char* format, ...) {
 }
 
 static const bits_btn_obj_param_t defaul_param = {.long_press_period_triger_ms = BITS_BTN_LONG_PRESS_PERIOD_TRIGER_MS,
-    .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
-    .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
-    .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
+                                                  .long_press_start_time_ms = BITS_BTN_LONG_PRESS_START_TIME_MS,
+                                                  .short_press_time_ms = BITS_BTN_SHORT_TIME_MS,
+                                                  .time_window_time_ms = BITS_BTN_TIME_WINDOW_TIME_MS};
 button_obj_t btns[] =
 {
     BITS_BUTTON_INIT(USER_BUTTON_0, 1, &defaul_param),
@@ -64,26 +61,18 @@ button_obj_t btns[] =
 button_obj_combo_t btns_combo[] =
 {
     BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_0, 1, &defaul_param, ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1}), 2, 1),
-    BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_1, 1, &defaul_param, ((uint16_t[]){USER_BUTTON_2, USER_BUTTON_3}), 2, 1),
+    BITS_BUTTON_COMBO_INIT(USER_BUTTON_COMBO_1, 1, &defaul_param, ((uint16_t[]){USER_BUTTON_0, USER_BUTTON_1, USER_BUTTON_3}), 3, 1),
 };
 
 // 初始化适配器
 __attribute__((constructor)) static void init_adapter() {
-    // 替换所有button实例的读取函数
-    // struct button_obj_t* btn = button_list_head;
-    // while(btn) {
-    //     btn->_read_button_func_ptr = read_key_state;
-    //     btn = btn->next;
-    // }
-
-    bits_button_init(btns, ARRAY_SIZE(btns), btns_combo, ARRAY_SIZE(btns_combo), read_key_state, NULL, my_log_printf);
-#if 0
-    button_init(&button1, read_key_state, 1, 0, NULL, 0);
-    button_start(&button1);
-
-    button_init(&button2, read_key_state, 1, 1, NULL, 0);
-    button_start(&button2);
-#endif
+    int32_t ret = bits_button_init(btns, ARRAY_SIZE(btns), btns_combo, ARRAY_SIZE(btns_combo), read_key_state, NULL, my_log_printf);
+    if(ret)
+    {
+        printf("bits button init failed, ret:%d \r\n", ret);
+    }
+    else
+        printf("bits button success!\n");
 
 }
 


### PR DESCRIPTION
Why: 当多个组合按键同时满足条件时，应该只激活按键数量最多的组合（即最具体的组合），而不是所有满足条件的组合;