### PR TITLE
New: support c89 c99

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,33 +23,33 @@ set(TEST_SOURCES
     # 核心框架
     core/test_framework.c
     core/test_runner.c
-    
+
     # 工具库
     utils/mock_utils.c
     utils/time_utils.c
     utils/assert_utils.c
-    
+
     # 测试用例 - 基础功能
     cases/basic/test_single_operations.c
     cases/basic/test_buffer_operations.c
     cases/basic/test_initialization.c
     cases/basic/test_state_reset.c
-    
+
     # 测试用例 - 组合按键
     cases/combo/test_combo_buttons.c
     cases/combo/test_advanced_combo.c
-    
+
     # 测试用例 - 边界测试
     cases/edge/test_edge_cases.c
     cases/edge/test_state_machine_edge.c
     cases/edge/test_error_handling.c
-    
+
     # 测试用例 - 性能测试
     cases/performance/test_performance.c
-    
+
     # Unity测试框架
     Unity/src/unity.c
-    
+
     # 被测试的源文件
     ${CMAKE_CURRENT_SOURCE_DIR}/../bits_button.c
 )

--- a/test/cases/basic/test_buffer_operations.c
+++ b/test/cases/basic/test_buffer_operations.c
@@ -23,184 +23,184 @@ void buffer_tearDown(void) {
 
 void test_buffer_overflow_protection(void) {
     printf("\n=== 测试缓冲区溢出保护 ===\n");
-    
+
     // 创建按键对象
     static const bits_btn_obj_param_t param = TEST_DEFAULT_PARAM();
     button_obj_t button = BITS_BUTTON_INIT(1, 1, &param);
-    bits_button_init(&button, 1, NULL, 0, 
-                     test_framework_mock_read_button, 
-                     test_framework_event_callback, 
+    bits_button_init(&button, 1, NULL, 0,
+                     test_framework_mock_read_button,
+                     test_framework_event_callback,
                      test_framework_log_printf);
 
     // 记录初始的溢出计数
-    size_t initial_overwrite_count = get_bits_btn_overwrite_count();
-    size_t initial_buffer_count = get_bits_btn_buffer_count();
-    
+    size_t initial_overwrite_count = get_bits_btn_buffer_overwrite_count();
+    size_t initial_buffer_count = get_bits_btn_buffer_used_count();
+
     // 快速产生大量事件，超过缓冲区大小
-    const int excess_events = BITS_BTN_BUFFER_SIZE + 5;
+    const int excess_events = get_bits_btn_buffer_capacity() + 5;
     for (int i = 0; i < excess_events; i++) {
         mock_button_click(1, STANDARD_CLICK_TIME_MS);
         time_simulate_time_window_end();
-        
+
         // 每次都调用ticks来处理事件
         bits_button_ticks();
     }
-    
+
     // 检查是否发生了溢出
-    size_t final_overwrite_count = get_bits_btn_overwrite_count();
-    size_t final_buffer_count = get_bits_btn_buffer_count();
-    
+    size_t final_overwrite_count = get_bits_btn_buffer_overwrite_count();
+    size_t final_buffer_count = get_bits_btn_buffer_used_count();
+
     // 验证溢出保护机制
     if (final_overwrite_count > initial_overwrite_count) {
         // 发生了溢出，这是预期的
         size_t overflow_count = final_overwrite_count - initial_overwrite_count;
         TEST_ASSERT_TRUE_MESSAGE(overflow_count > 0, "应该检测到缓冲区溢出");
         printf("✓ 缓冲区溢出保护正常工作: 溢出次数 = %zu\n", overflow_count);
-        
+
         // 验证缓冲区大小没有超过限制
-        TEST_ASSERT_TRUE_MESSAGE(final_buffer_count <= BITS_BTN_BUFFER_SIZE, 
+        TEST_ASSERT_TRUE_MESSAGE(final_buffer_count <= get_bits_btn_buffer_capacity(),
                                  "缓冲区大小不应超过最大限制");
     } else {
         // 没有溢出，说明缓冲区容量足够大
         printf("✓ 缓冲区未溢出，容量足够\n");
-        
+
         // 验证所有事件都被正确存储
-        TEST_ASSERT_TRUE_MESSAGE(final_buffer_count >= initial_buffer_count, 
+        TEST_ASSERT_TRUE_MESSAGE(final_buffer_count >= initial_buffer_count,
                                  "缓冲区应该包含新增的事件");
     }
-    
+
     // 验证缓冲区状态检查函数的正确性
     bool is_full = bits_btn_is_buffer_full();
     bool is_empty = bits_btn_is_buffer_empty();
-    size_t buffer_count = get_bits_btn_buffer_count();
-    
+    size_t buffer_count = get_bits_btn_buffer_used_count();
+
     // 基本状态一致性检查
     TEST_ASSERT_FALSE_MESSAGE(is_full && is_empty, "缓冲区不能同时为满和空");
-    
+
     if (is_empty) {
         TEST_ASSERT_EQUAL_MESSAGE(0, buffer_count, "空缓冲区的元素数量应该为0");
     } else {
         TEST_ASSERT_TRUE_MESSAGE(buffer_count > 0, "非空缓冲区的元素数量应该大于0");
     }
-    
+
     if (is_full) {
-        TEST_ASSERT_TRUE_MESSAGE(buffer_count >= BITS_BTN_BUFFER_SIZE * 0.8, 
+        TEST_ASSERT_TRUE_MESSAGE(buffer_count >= get_bits_btn_buffer_capacity() * 0.8,
                                  "满缓冲区的元素数量应该接近最大值");
     }
-    
-    printf("缓冲区状态: 满=%s, 空=%s, 元素数量=%zu\n", 
-           is_full ? "是" : "否", 
-           is_empty ? "是" : "否", 
+
+    printf("缓冲区状态: 满=%s, 空=%s, 元素数量=%zu\n",
+           is_full ? "是" : "否",
+           is_empty ? "是" : "否",
            buffer_count);
-    
+
     // 验证系统在溢出后仍能正常工作
     test_framework_reset();  // 清理事件缓冲区
     mock_button_click(1, STANDARD_CLICK_TIME_MS);
     time_simulate_time_window_end();
     bits_button_ticks();
-    
+
     // 应该能正常获取新事件
     bits_btn_result_t result;
     bool got_result = bits_button_get_key_result(&result);
     TEST_ASSERT_TRUE_MESSAGE(got_result, "溢出后系统应该仍能正常处理新事件");
     TEST_ASSERT_EQUAL_MESSAGE(1, result.key_id, "事件内容应该正确");
-    
+
     printf("✓ 缓冲区溢出保护测试通过\n");
 }
 
 void test_buffer_state_tracking(void) {
     printf("\n=== 测试缓冲区状态跟踪 ===\n");
-    
+
     // 创建按键对象
     static const bits_btn_obj_param_t param = TEST_DEFAULT_PARAM();
     button_obj_t button = BITS_BUTTON_INIT(1, 1, &param);
-    bits_button_init(&button, 1, NULL, 0, 
-                     test_framework_mock_read_button, 
-                     test_framework_event_callback, 
+    bits_button_init(&button, 1, NULL, 0,
+                     test_framework_mock_read_button,
+                     test_framework_event_callback,
                      test_framework_log_printf);
 
     // 初始状态应该是空的
     TEST_ASSERT_TRUE(bits_btn_is_buffer_empty());
     TEST_ASSERT_FALSE(bits_btn_is_buffer_full());
-    TEST_ASSERT_EQUAL(0, get_bits_btn_buffer_count());
-    
+    TEST_ASSERT_EQUAL(0, get_bits_btn_buffer_used_count());
+
     // 产生一些事件
     mock_button_click(1, STANDARD_CLICK_TIME_MS);
     time_simulate_time_window_end();
     bits_button_ticks();
-    
+
     // 缓冲区应该不再为空
     TEST_ASSERT_FALSE(bits_btn_is_buffer_empty());
-    TEST_ASSERT_TRUE(get_bits_btn_buffer_count() > 0);
-    
+    TEST_ASSERT_TRUE(get_bits_btn_buffer_used_count() > 0);
+
     // 读取事件
     bits_btn_result_t result;
     bool got_result = bits_button_get_key_result(&result);
     TEST_ASSERT_TRUE(got_result);
     TEST_ASSERT_EQUAL(1, result.key_id);
-    
+
     // 读取后缓冲区计数应该减少
-    size_t count_after_read = get_bits_btn_buffer_count();
+    size_t count_after_read = get_bits_btn_buffer_used_count();
     printf("读取事件后缓冲区元素数量: %zu\n", count_after_read);
-    
+
     printf("缓冲区状态跟踪测试通过\n");
 }
 
 void test_buffer_edge_cases(void) {
     printf("\n=== 测试缓冲区边界情况 ===\n");
-    
+
     // 创建按键对象
     static const bits_btn_obj_param_t param = TEST_DEFAULT_PARAM();
     button_obj_t button = BITS_BUTTON_INIT(1, 1, &param);
-    bits_button_init(&button, 1, NULL, 0, 
-                     test_framework_mock_read_button, 
-                     test_framework_event_callback, 
+    bits_button_init(&button, 1, NULL, 0,
+                     test_framework_mock_read_button,
+                     test_framework_event_callback,
                      test_framework_log_printf);
 
     // 测试从空缓冲区读取
     bits_btn_result_t result;
     bool got_result = bits_button_get_key_result(&result);
     TEST_ASSERT_FALSE(got_result);  // 应该返回false，因为缓冲区为空
-    
+
     // 填满缓冲区
-    for (int i = 0; i < BITS_BTN_BUFFER_SIZE; i++) {
+    for (size_t i = 0; i < get_bits_btn_buffer_capacity(); i++) {
         mock_button_click(1, STANDARD_CLICK_TIME_MS);
         time_simulate_time_window_end();
         bits_button_ticks();
     }
-    
+
     // 检查缓冲区是否接近满状态
-    size_t buffer_count = get_bits_btn_buffer_count();
+    size_t buffer_count = get_bits_btn_buffer_used_count();
     printf("填充后缓冲区元素数量: %zu\n", buffer_count);
-    
+
     // 尝试再添加事件（可能导致溢出）
-    size_t overwrite_before = get_bits_btn_overwrite_count();
+    size_t overwrite_before = get_bits_btn_buffer_overwrite_count();
     mock_button_click(1, STANDARD_CLICK_TIME_MS);
     time_simulate_time_window_end();
     bits_button_ticks();
-    size_t overwrite_after = get_bits_btn_overwrite_count();
-    
+    size_t overwrite_after = get_bits_btn_buffer_overwrite_count();
+
     if (overwrite_after > overwrite_before) {
-        printf("✓ 缓冲区溢出处理正常: 新溢出次数 = %zu\n", 
+        printf("✓ 缓冲区溢出处理正常: 新溢出次数 = %zu\n",
                overwrite_after - overwrite_before);
     }
-    
+
     // 逐个读取所有事件
-    int read_count = 0;
+    size_t read_count = 0;
     while (bits_button_get_key_result(&result)) {
         read_count++;
         TEST_ASSERT_EQUAL(1, result.key_id);
-        
+
         // 防止无限循环
-        if (read_count > BITS_BTN_BUFFER_SIZE + 10) {
+        if (read_count > get_bits_btn_buffer_capacity() + 10) {
             break;
         }
     }
-    
-    printf("成功读取事件数量: %d\n", read_count);
-    
+
+    printf("成功读取事件数量: %llu\n", read_count);
+
     // 读取完毕后缓冲区应该为空
     TEST_ASSERT_TRUE(bits_btn_is_buffer_empty());
-    
+
     printf("缓冲区边界情况测试通过\n");
 }

--- a/test/scripts/run_tests.bat
+++ b/test/scripts/run_tests.bat
@@ -63,7 +63,7 @@ if "%CI_MODE%"=="true" (
 if %errorlevel% neq 0 (
     echo ❌ CMake配置失败！
     echo 当前目录: %CD%
-    echo 查找CMakeLists.txt: 
+    echo 查找CMakeLists.txt:
     if exist "..\CMakeLists.txt" (
         echo   ✓ 找到 ..\CMakeLists.txt
     ) else (
@@ -114,6 +114,64 @@ echo.
 echo ========================================
 if !test_result! equ 0 (
     echo ✅ 所有测试通过！
+
+    REM 额外执行编译配置验证
+    echo.
+    echo 🔧 【额外验证】编译配置兼容性
+    echo ----------------------------------------
+
+    REM 切换到项目根目录进行编译测试
+    cd /d "%TEST_DIR%\.."
+
+    echo 测试编译指令1: gcc -c -DBITS_BTN_DISABLE_BUFFER -std=c99 bits_button.c
+    gcc -c -DBITS_BTN_DISABLE_BUFFER -std=c99 bits_button.c -o bits_button_disable.o 2>compile_error1.log
+    if !errorlevel! equ 0 (
+        echo ✅ 禁用缓冲区模式 C99 编译成功
+        if exist "bits_button_disable.o" del "bits_button_disable.o" 2>nul
+        if exist "compile_error1.log" del "compile_error1.log" 2>nul
+    ) else (
+        echo ❌ 禁用缓冲区模式 C99 编译失败
+        echo 错误信息：
+        if exist "compile_error1.log" (
+            type "compile_error1.log"
+            del "compile_error1.log" 2>nul
+        )
+    )
+
+    echo 测试编译指令2: gcc -c -DBITS_BTN_USE_USER_BUFFER -std=c99 bits_button.c
+    gcc -c -DBITS_BTN_USE_USER_BUFFER -std=c99 bits_button.c -o bits_button_user.o 2>compile_error2.log
+    if !errorlevel! equ 0 (
+        echo ✅ 用户缓冲区模式 C99 编译成功
+        if exist "bits_button_user.o" del "bits_button_user.o" 2>nul
+        if exist "compile_error2.log" del "compile_error2.log" 2>nul
+    ) else (
+        echo ❌ 用户缓冲区模式 C99 编译失败
+        echo 错误信息：
+        if exist "compile_error2.log" (
+            type "compile_error2.log"
+            del "compile_error2.log" 2>nul
+        )
+    )
+
+    echo 测试编译指令3: gcc -c -std=c11 bits_button.c
+    gcc -c -std=c11 bits_button.c -o bits_button_default.o 2>compile_error3.log
+    if !errorlevel! equ 0 (
+        echo ✅ 默认模式 C11 编译成功
+        if exist "bits_button_default.o" del "bits_button_default.o" 2>nul
+        if exist "compile_error3.log" del "compile_error3.log" 2>nul
+    ) else (
+        echo ❌ 默认模式 C11 编译失败
+        echo 错误信息：
+        if exist "compile_error3.log" (
+            type "compile_error3.log"
+            del "compile_error3.log" 2>nul
+        )
+    )
+
+    echo ✅ 编译配置兼容性验证完成！
+
+    REM 返回到构建目录
+    cd /d "%TEST_DIR%\build"
 ) else (
     echo ❌ 测试失败！退出码: !test_result!
 )

--- a/test/scripts/run_tests.sh
+++ b/test/scripts/run_tests.sh
@@ -61,6 +61,59 @@ fi
 echo "========================================="
 if [ $TEST_RESULT -eq 0 ]; then
     echo "✅ 所有测试通过！"
+
+    # 额外执行编译配置验证
+    echo ""
+    echo "🔧 【额外验证】编译配置兼容性"
+    echo "----------------------------------------"
+
+    # 切换到项目根目录进行编译测试
+    cd ..
+
+    echo "测试编译指令1: gcc -c -DBITS_BTN_DISABLE_BUFFER -std=c99 bits_button.c"
+    if gcc -c -DBITS_BTN_DISABLE_BUFFER -std=c99 bits_button.c -o bits_button_disable.o 2>compile_error1.log; then
+        echo "✅ 禁用缓冲区模式 C99 编译成功"
+        [ -f "bits_button_disable.o" ] && rm -f "bits_button_disable.o"
+        [ -f "compile_error1.log" ] && rm -f "compile_error1.log"
+    else
+        echo "❌ 禁用缓冲区模式 C99 编译失败"
+        echo "错误信息："
+        if [ -f "compile_error1.log" ]; then
+            cat "compile_error1.log"
+            rm -f "compile_error1.log"
+        fi
+    fi
+
+    echo "测试编译指令2: gcc -c -DBITS_BTN_USE_USER_BUFFER -std=c99 bits_button.c"
+    if gcc -c -DBITS_BTN_USE_USER_BUFFER -std=c99 bits_button.c -o bits_button_user.o 2>compile_error2.log; then
+        echo "✅ 用户缓冲区模式 C99 编译成功"
+        [ -f "bits_button_user.o" ] && rm -f "bits_button_user.o"
+        [ -f "compile_error2.log" ] && rm -f "compile_error2.log"
+    else
+        echo "❌ 用户缓冲区模式 C99 编译失败"
+        echo "错误信息："
+        if [ -f "compile_error2.log" ]; then
+            cat "compile_error2.log"
+            rm -f "compile_error2.log"
+        fi
+    fi
+
+    echo "测试编译指令3: gcc -c -std=c11 bits_button.c"
+    if gcc -c -std=c11 bits_button.c -o bits_button_default.o 2>compile_error3.log; then
+        echo "✅ 默认模式 C11 编译成功"
+        [ -f "bits_button_default.o" ] && rm -f "bits_button_default.o"
+        [ -f "compile_error3.log" ] && rm -f "compile_error3.log"
+    else
+        echo "❌ 默认模式 C11 编译失败"
+        echo "错误信息："
+        if [ -f "compile_error3.log" ]; then
+            cat "compile_error3.log"
+            rm -f "compile_error3.log"
+        fi
+    fi
+
+    echo "✅ 编译配置兼容性验证完成！"
+
     exit 0
 else
     echo "❌ 测试失败！退出码: $TEST_RESULT"

--- a/test/test_main_new.c
+++ b/test/test_main_new.c
@@ -113,15 +113,15 @@ void tearDown(void) {
 int main(void) {
     // 初始化Unity测试框架
     UNITY_BEGIN();
-    
+
     printf("========================================\n");
     printf("     BitsButton 测试框架 v3.0\n");
     printf("     分层架构 - 模块化设计\n");
     printf("========================================\n\n");
-    
+
     // 初始化测试框架
     test_framework_init();
-    
+
     printf("【单按键基础功能测试】\n");
     RUN_TEST(test_single_click_event);
     RUN_TEST(test_double_click_event);
@@ -130,60 +130,60 @@ int main(void) {
     RUN_TEST(test_long_press_hold_event);
     RUN_TEST(test_state_reset_functionality);
     RUN_TEST(test_combo_button_reset);
-    
+
     printf("\n【组合按键功能测试】\n");
     RUN_TEST(test_basic_combo_button);
     RUN_TEST(test_combo_long_press);
-    
+
     printf("\n【边界条件测试】\n");
     RUN_TEST(test_slow_double_click_timeout);
     RUN_TEST(test_debounce_functionality);
     RUN_TEST(test_very_short_press);
     RUN_TEST(test_long_press_boundary);
     RUN_TEST(test_rapid_clicks_boundary);
-    
+
     printf("\n【性能压力测试】\n");
     RUN_TEST(test_high_frequency_button_presses);
     RUN_TEST(test_multiple_buttons_concurrent);
     RUN_TEST(test_long_running_stability);
     RUN_TEST(test_memory_usage);
-    
+
     printf("\n【缓冲区操作测试】\n");
     RUN_TEST(test_buffer_overflow_protection);
     RUN_TEST(test_buffer_state_tracking);
     RUN_TEST(test_buffer_edge_cases);
-    
+
     printf("\n【高级组合按键测试】\n");
     RUN_TEST(test_advanced_three_key_combo);
     RUN_TEST(test_combo_with_different_timing);
     RUN_TEST(test_multiple_combos_conflict);
-    
+
     printf("\n【状态机边界测试】\n");
     RUN_TEST(test_state_transition_timing);
     RUN_TEST(test_time_window_boundary);
     RUN_TEST(test_long_press_period_boundary);
     RUN_TEST(test_rapid_state_changes);
-    
+
     printf("\n【错误处理测试】\n");
     RUN_TEST(test_null_pointer_handling);
     RUN_TEST(test_invalid_parameters);
     RUN_TEST(test_boundary_values);
     RUN_TEST(test_resource_exhaustion);
-    
+
     printf("\n【初始化配置测试】\n");
     RUN_TEST(test_successful_initialization);
     RUN_TEST(test_different_active_levels);
     RUN_TEST(test_custom_parameters);
     RUN_TEST(test_multiple_button_initialization);
     RUN_TEST(test_callback_functions);
-    
+
     printf("\n========================================\n");
     printf("           测试完成\n");
     printf("========================================\n");
-    
+
     // 清理资源
     test_framework_cleanup();
-    
+
     // 返回测试结果
     return UNITY_END();
 }


### PR DESCRIPTION
Why: requirements development

What: as follows
1. New compilation macros have been added to select different buffer modes: 1) Disable buffer;
2) Use user buffer;
3) Use c11 atomic buffer by default;
2. Support adding new compilation macro test cases;
3. Readme doc update;